### PR TITLE
Add Vitest and unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,16 @@
     "@typescript-eslint/parser": "^5.53.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.3.4"
+    "eslint-plugin-react-refresh": "^0.3.4",
+    "vitest": "^0.34.6"
   },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint src --ext js,jsx,ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest"
   },
   "eslintConfig": {
     "extends": [

--- a/src/utils/__tests__/formatting.test.js
+++ b/src/utils/__tests__/formatting.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { generateInitials, formatCurrency } from '../formatting';
+
+describe('generateInitials', () => {
+  it('returns initials from first and last name', () => {
+    expect(generateInitials('John', 'Doe')).toBe('JD');
+  });
+
+  it('handles missing last name', () => {
+    expect(generateInitials('John')).toBe('J');
+  });
+
+  it('handles missing first name', () => {
+    expect(generateInitials(undefined, 'Doe')).toBe('D');
+  });
+
+  it('returns ? when both names are missing', () => {
+    expect(generateInitials()).toBe('?');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('formats valid numbers as USD currency', () => {
+    expect(formatCurrency(1234.56)).toBe('$1,234.56');
+  });
+
+  it('returns $0.00 for invalid input', () => {
+    expect(formatCurrency('foo')).toBe('$0.00');
+    expect(formatCurrency(NaN)).toBe('$0.00');
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,21 +1,17 @@
-// medspasync-frontend/vite.config.js
-import { defineConfig } from 'vite'; // <<-- THIS LINE IS THE FIX
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [
-    react(), // This plugin is crucial for React and JSX transformation
-  ],
+  plugins: [react()],
   css: {
-    postcss: './postcss.config.js', // Explicitly tell Vite where to find PostCSS config
+    postcss: './postcss.config.js',
   },
   build: {
-    outDir: 'dist', // Default build output directory for Vite
-    emptyOutDir: true, // Clears the output directory before building
+    outDir: 'dist',
+    emptyOutDir: true,
   },
-  // You can add other configurations here if needed, e.g., for server port, host:
-  // server: {
-  //   port: 5173, // Ensure this matches the port you expect
-  //   host: true, // For Codespaces, helps expose to network
-  // }
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 });


### PR DESCRIPTION
## Summary
- enable Vitest and add test script
- configure Vitest in `vite.config.js`
- add tests for `generateInitials` and `formatCurrency`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477696efc88332a9c79915c33aeea0