### PR TITLE
Refactor DeleteConfirmModal for generic usage

### DIFF
--- a/src/components/DeleteConfirmModal.jsx
+++ b/src/components/DeleteConfirmModal.jsx
@@ -2,17 +2,21 @@ import React from 'react';
 import Modal from './Ui/Modal.jsx'; // Explicit .jsx extension
 import LoadingSpinner from './Ui/LoadingSpinner.jsx'; // Explicit .jsx extension
 
-// Delete Confirmation Modal (Reusable for any deletion)
-const DeleteConfirmModal = React.memo(({ client, isOpen, onClose, onConfirm, isLoading }) => {
+// Generic Delete Confirmation Modal with customizable title and message
+const DeleteConfirmModal = React.memo(({
+  isOpen,
+  onClose,
+  onConfirm,
+  isLoading,
+  title = 'Delete Item',
+  message = 'Are you sure you want to delete this item? This action cannot be undone.'
+}) => {
   if (!isOpen) return null; // Render nothing if not open
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Confirm Deletion" showCloseButton={true}>
-      <h3 className="text-lg font-semibold text-gray-900 mb-2">Delete Client</h3>
-      <p className="text-gray-600 mb-6">
-        Are you sure you want to delete <strong>{client?.firstName} {client?.lastName}</strong>? 
-        This action cannot be undone and will remove all associated appointment history.
-      </p>
+      <h3 className="text-lg font-semibold text-gray-900 mb-2">{title}</h3>
+      <p className="text-gray-600 mb-6">{message}</p>
       <div className="flex gap-3">
         <button
           type="button"

--- a/src/pages/AppointmentsPage.jsx
+++ b/src/pages/AppointmentsPage.jsx
@@ -592,7 +592,6 @@ const AppointmentsPage = React.memo(() => {
         />
 
         <DeleteConfirmModal
-          item={selectedAppointment}
           isOpen={showDeleteModal}
           onClose={() => {
             setShowDeleteModal(false);
@@ -601,7 +600,7 @@ const AppointmentsPage = React.memo(() => {
           onConfirm={handleDeleteAppointment}
           isLoading={deleteAppointmentMutation.isLoading}
           title="Delete Appointment"
-          message={selectedAppointment ? 
+          message={selectedAppointment ?
             `Are you sure you want to delete this appointment for ${selectedAppointment.client?.firstName} ${selectedAppointment.client?.lastName} on ${format(parseISO(selectedAppointment.dateTime), 'MMM d, h:mm a')}? This action cannot be undone.` :
             'Are you sure you want to delete this appointment?'
           }

--- a/src/pages/ClientsPage.jsx
+++ b/src/pages/ClientsPage.jsx
@@ -268,7 +268,6 @@ const ClientsPage = React.memo(() => {
         />
 
         <DeleteConfirmModal
-          client={selectedClient} // Client to delete
           isOpen={showDeleteModal}
           onClose={() => {
             setShowDeleteModal(false);
@@ -276,6 +275,12 @@ const ClientsPage = React.memo(() => {
           }}
           onConfirm={handleDeleteClient}
           isLoading={deleteClientMutation.isLoading}
+          title="Delete Client"
+          message={selectedClient ? (
+            <>Are you sure you want to delete <strong>{selectedClient.firstName} {selectedClient.lastName}</strong>? This action cannot be undone and will remove all associated appointment history.</>
+          ) : (
+            'Are you sure you want to delete this client? This action cannot be undone and will remove all associated appointment history.'
+          )}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- refactor DeleteConfirmModal to take generic `title` and `message` props
- update ClientsPage and AppointmentsPage usages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684776926fe483329cb4ca1c02e72f2b