### PR TITLE
Fix README path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A comprehensive spa management system built with React, featuring client managem
 1. **Clone and install dependencies**
    ```bash
    git clone <repository-url>
-   cd medspa-management-app
+   cd medspasync-frontend
    npm install
    ```
 


### PR DESCRIPTION
## Summary
- update the setup path in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6847768c91e88332b86c9dc2ff0377dc