### PR TITLE
Remove production debug logs

### DIFF
--- a/src/hooks/useWebSocket.js
+++ b/src/hooks/useWebSocket.js
@@ -49,7 +49,9 @@ export const useWebSocket = (originalUrl, options = {}) => {
     if (requiresAuth && (!isAuthenticated || !user || authLoading)) {
       setConnectionStatus('Waiting for authentication...');
       setReadyState(WebSocket.CLOSED);
-      console.log('WebSocket: Waiting for authentication before connecting.');
+      if (import.meta.env.MODE !== 'production') {
+        console.log('WebSocket: Waiting for authentication before connecting.');
+      }
       return;
     }
 
@@ -81,7 +83,9 @@ export const useWebSocket = (originalUrl, options = {}) => {
         setConnectionStatus('Open');
         reconnectCount.current = 0;
         if (onOpen) onOpen(event);
-        console.log('WebSocket: Connected successfully to', wsUrl);
+        if (import.meta.env.MODE !== 'production') {
+          console.log('WebSocket: Connected successfully to', wsUrl);
+        }
       };
 
       ws.onclose = (event) => {
@@ -89,12 +93,18 @@ export const useWebSocket = (originalUrl, options = {}) => {
         setReadyState(WebSocket.CLOSED);
         setConnectionStatus('Closed');
         if (onClose) onClose(event);
-        console.log('WebSocket: Connection closed.', event.code, event.reason);
+        if (import.meta.env.MODE !== 'production') {
+          console.log('WebSocket: Connection closed.', event.code, event.reason);
+        }
 
         if (shouldReconnect && reconnectCount.current < reconnectAttempts && !event.wasClean) {
           reconnectCount.current++;
           setConnectionStatus(`Reconnecting (Attempt ${reconnectCount.current}/${reconnectAttempts})...`);
-          console.log(`WebSocket: Reconnecting (Attempt ${reconnectCount.current})...`);
+          if (import.meta.env.MODE !== 'production') {
+            console.log(
+              `WebSocket: Reconnecting (Attempt ${reconnectCount.current})...`
+            );
+          }
           reconnectTimeoutId.current = setTimeout(() => {
             if (isMounted.current) connect();
           }, reconnectInterval);

--- a/src/pages/ClientsPage.jsx
+++ b/src/pages/ClientsPage.jsx
@@ -92,7 +92,9 @@ const ClientsPage = React.memo(() => {
 
   const handleViewClient = useCallback((client) => {
     // Implement client detail view (e.g., open a modal, navigate to /clients/:id)
-    console.log('Viewing client:', client);
+    if (import.meta.env.MODE !== 'production') {
+      console.log('Viewing client:', client);
+    }
     toast.info(`View Client: ${client.firstName} ${client.lastName}`);
   }, []);
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -99,4 +99,6 @@ export const CLIENT_STATUS = {
 };
 
 // Debug logging to see what URL is being used
-console.log('API_BASE_URL:', API_BASE_URL);
+if (import.meta.env.MODE !== 'production') {
+  console.log('API_BASE_URL:', API_BASE_URL);
+}


### PR DESCRIPTION
## Summary
- stop logging API base URL in production
- wrap websocket debug logs behind environment check
- silence client view log in production

## Testing
- `npm test --silent` *(fails: Cannot find module '@tailwindcss/postcss')*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68477963402083328a1afb024ca35fcb