### PR TITLE
Implement subscription gating for exports

### DIFF
--- a/src/components/ReconciliationRunner.jsx
+++ b/src/components/ReconciliationRunner.jsx
@@ -3,8 +3,11 @@ import React, { useState } from 'react';
 import { saveAs } from 'file-saver';
 import toast from 'react-hot-toast';
 import api from '../services/api.js';
+import { useAuth } from '../services/AuthContext.jsx';
+import { canExport } from '../utils/access.js';
 
 function ReconciliationRunner() {
+  const { subscriptionTier } = useAuth();
   const [file1, setFile1] = useState(null);
   const [file2, setFile2] = useState(null);
   const [file3, setFile3] = useState(null);
@@ -71,11 +74,17 @@ function ReconciliationRunner() {
             <h2 className="text-xl font-semibold mb-2">Summary</h2>
             <pre className="text-sm overflow-auto whitespace-pre-wrap">{JSON.stringify(results.summary, null, 2)}</pre>
             <button
-              className="mt-4 bg-green-600 text-white px-4 py-2 rounded"
+              className="mt-4 bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
               onClick={handleExportPDF}
+              disabled={!canExport(subscriptionTier)}
             >
               Export PDF
             </button>
+            {!canExport(subscriptionTier) && (
+              <p className="text-xs text-gray-500 mt-2">
+                Upgrade to Professional to export reports.
+              </p>
+            )}
           </div>
         )}
       </div>

--- a/src/utils/__tests__/access.test.js
+++ b/src/utils/__tests__/access.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { canExport, canUsePremiumFeatures } from '../access';
+
+describe('subscription access helpers', () => {
+  it('allows export for professional plan', () => {
+    expect(canExport('professional')).toBe(true);
+  });
+
+  it('blocks export for core plan', () => {
+    expect(canExport('core')).toBe(false);
+  });
+
+  it('allows premium features only for professional plan', () => {
+    expect(canUsePremiumFeatures('professional')).toBe(true);
+    expect(canUsePremiumFeatures('core')).toBe(false);
+  });
+});

--- a/src/utils/access.js
+++ b/src/utils/access.js
@@ -1,0 +1,2 @@
+export const canExport = (plan) => plan === 'professional';
+export const canUsePremiumFeatures = (plan) => plan === 'professional';


### PR DESCRIPTION
## Summary
- restrict export actions based on subscription tier
- centralize tier helper functions
- test helper logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68485c6921308332bbb18a36a81fab33