### PR TITLE
Fix landing/login/register auth flows

### DIFF
--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -4,10 +4,11 @@ import Modal from '../components/Ui/Modal.jsx';
 import { useForm } from '../hooks/useForm.js';
 import { validationSchemas } from '../utils/validation.js';
 import { useAuth } from '../services/AuthContext.jsx';
+import LoadingScreen from '../components/Common/LoadingScreen.jsx';
 
 const LoginPage = React.memo(() => {
     const navigate = useNavigate();
-    const { login, error: authError, clearError } = useAuth();
+    const { login, error: authError, clearError, isAuthenticated, isLoading } = useAuth();
     const [showPassword, setShowPassword] = useState(false);
     const [showModal, setShowModal] = useState(false);
     const [modalConfig, setModalConfig] = useState({});
@@ -28,13 +29,22 @@ const LoginPage = React.memo(() => {
         clearError();
     }, [clearError, reset]);
 
+    useEffect(() => {
+        if (!isLoading && isAuthenticated) {
+            navigate('/dashboard', { replace: true });
+        }
+    }, [isAuthenticated, isLoading, navigate]);
+
     const onSubmit = useCallback(async (formData) => {
         try {
-            await login(formData);
+            const success = await login(formData);
+            if (success) {
+                navigate('/dashboard');
+            }
         } catch (err) {
             // Error handled by AuthContext
         }
-    }, [login]);
+    }, [login, navigate]);
 
     const fillDemoCredentials = useCallback(() => {
         setValues(prev => ({
@@ -57,6 +67,10 @@ const LoginPage = React.memo(() => {
         });
         setShowModal(true);
     }, []);
+
+    if (isLoading) {
+        return <LoadingScreen message="Loading user session..." />;
+    }
 
     return (
         <div className="min-h-screen bg-gradient-to-br from-indigo-100 via-white to-purple-100 flex items-center justify-center px-4">

--- a/src/services/AuthContext.jsx
+++ b/src/services/AuthContext.jsx
@@ -8,6 +8,7 @@ const AuthContext = createContext(null);
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(() => storageService.getUserData());
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   const initialize = useCallback(async () => {
     const token = storageService.getAuthToken();
@@ -31,12 +32,30 @@ export const AuthProvider = ({ children }) => {
   }, [initialize]);
 
   const login = async (credentials) => {
+    setError(null);
     try {
       const res = await authService.login(credentials);
       setUser(res.user);
       toast.success('Login successful');
       return true;
     } catch (err) {
+      setError(err.message);
+      toast.error(err.message);
+      return false;
+    }
+  };
+
+  const register = async (data) => {
+    setError(null);
+    try {
+      const res = await authService.register(data);
+      if (res.user) {
+        setUser(res.user);
+      }
+      toast.success('Registration successful');
+      return true;
+    } catch (err) {
+      setError(err.message);
       toast.error(err.message);
       return false;
     }
@@ -47,6 +66,8 @@ export const AuthProvider = ({ children }) => {
     setUser(null);
     toast.success('Logged out');
   };
+
+  const clearError = () => setError(null);
 
   const refreshToken = async () => {
     try {
@@ -64,8 +85,11 @@ export const AuthProvider = ({ children }) => {
         user,
         isLoading,
         login,
+        register,
         logout,
+        clearError,
         refreshToken,
+        error,
         isAuthenticated: !!user,
         role: user?.role,
         practiceId: user?.practiceId,

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,19 @@
+export const decodeJWT = (token) => {
+  if (!token) return null;
+  try {
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    );
+    return JSON.parse(jsonPayload);
+  } catch (error) {
+    console.warn('JWT decode failed:', error);
+    return null;
+  }
+};
+
+export default decodeJWT;


### PR DESCRIPTION
## Summary
- add register and error handling to `AuthContext`
- load token helper via new `jwt` util
- improve landing page auth checks
- redirect on login & registration
- block login/register when authenticated

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848efd5374083329fa8d4ae5a2921b0