### PR TITLE
Refactor dark mode persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,15 @@
     <title>MedSpaSync Pro - Medical Spa Management Platform</title>
   </head>
   <body>
+    <script>
+      if (
+        localStorage.getItem('darkMode') === 'true' ||
+        (!localStorage.getItem('darkMode') &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches)
+      ) {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <div id="modal-root"></div>

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -14,7 +14,11 @@ const LandingPage = React.memo(() => {
     window.location.href = '/login';
   }, []);
 
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(() => {
+    const stored = localStorage.getItem('darkMode');
+    if (stored) return stored === 'true';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
   const [userName, setUserName] = useState('');
   const version = import.meta.env.VITE_APP_VERSION || '1.0.0';
 
@@ -26,10 +30,6 @@ const LandingPage = React.memo(() => {
     }
   }, [isAuthenticated, isLoading]);
 
-  useEffect(() => {
-    const storedMode = localStorage.getItem('darkMode');
-    if (storedMode === 'true') setDarkMode(true);
-  }, []);
 
   useEffect(() => {
     const root = document.documentElement;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,14 +1,10 @@
 // medspasync-frontend/tailwind.config.js
 /** @type {import('tailwindcss').Config} */
-export default { // Use export default for ESM compatibility
-  content: [
-    "./index.html",
-    "./src/**/*.{js,jsx}", // Ensure both .js and .jsx files are scanned
-  ],
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,jsx}'],
   theme: {
-    extend: {
-      // Customizations for your theme (colors, fonts, etc.) would go here
-    },
+    extend: {},
   },
-  plugins: [], // Any Tailwind plugins would be listed here
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode classes
- preload preferred theme in `index.html`
- persist dark mode preference in `LandingPage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f7f34d008332b593c311c24afc73