### PR TITLE
Add Support and Docs placeholder routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,8 @@ import AppointmentsPage from './pages/AppointmentsPage.jsx';
 import ServicesPage from './pages/ServicesPage.jsx';
 import NotFoundPage from './pages/NotFoundPage.jsx';
 import DemoReconciliation from './pages/DemoReconciliation.jsx';
+import SupportPage from './pages/SupportPage.jsx';
+import DocsPage from './pages/DocsPage.jsx';
 import ReconciliationRunner from './components/ReconciliationRunner';
 
 function AppContent() {
@@ -39,6 +41,8 @@ function AppContent() {
         <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
         <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
         <Route path="/demo" element={<PublicRoute><DemoReconciliation /></PublicRoute>} />
+        <Route path="/support" element={<PublicRoute><SupportPage /></PublicRoute>} />
+        <Route path="/docs" element={<PublicRoute><DocsPage /></PublicRoute>} />
 
         {/* Protected Routes */}
         <Route path="/dashboard" element={<ProtectedRoute requiredRoles={['admin', 'manager', 'staff', 'receptionist']}><DashboardPage /></ProtectedRoute>} />

--- a/src/pages/DocsPage.jsx
+++ b/src/pages/DocsPage.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 
 // TODO: Add comprehensive documentation for users
-const DocsPage = () => (
-  <div className="min-h-screen flex items-center justify-center">
-    <h1 className="text-2xl font-bold">Documentation</h1>
-  </div>
-);
+const DocsPage = () => <h1>Documentation</h1>;
 
 export default DocsPage;

--- a/src/pages/DocsPage.jsx
+++ b/src/pages/DocsPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// TODO: Add comprehensive documentation for users
+const DocsPage = () => (
+  <div className="min-h-screen flex items-center justify-center">
+    <h1 className="text-2xl font-bold">Documentation</h1>
+  </div>
+);
+
+export default DocsPage;

--- a/src/pages/SupportPage.jsx
+++ b/src/pages/SupportPage.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 
 // TODO: Add detailed support information and contact options
-const SupportPage = () => (
-  <div className="min-h-screen flex items-center justify-center">
-    <h1 className="text-2xl font-bold">Support</h1>
-  </div>
-);
+const SupportPage = () => <h1>Support</h1>;
 
 export default SupportPage;

--- a/src/pages/SupportPage.jsx
+++ b/src/pages/SupportPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// TODO: Add detailed support information and contact options
+const SupportPage = () => (
+  <div className="min-h-screen flex items-center justify-center">
+    <h1 className="text-2xl font-bold">Support</h1>
+  </div>
+);
+
+export default SupportPage;


### PR DESCRIPTION
## Summary
- add new SupportPage and DocsPage placeholders
- register SupportPage and DocsPage routes in App

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f95c69308332a52f02c01c5efa79