### PR TITLE
Add TopNav and improve personalized navigation

### DIFF
--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../services/AuthContext.jsx';
+
+const TopNav = () => {
+  const navigate = useNavigate();
+  const { isAuthenticated, firstName, logout } = useAuth();
+
+  const [darkMode, setDarkMode] = useState(() => {
+    const stored = localStorage.getItem('darkMode');
+    if (stored) return stored === 'true';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (darkMode) {
+      root.classList.add('dark');
+      localStorage.setItem('darkMode', 'true');
+    } else {
+      root.classList.remove('dark');
+      localStorage.setItem('darkMode', 'false');
+    }
+  }, [darkMode]);
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/');
+  };
+
+  return (
+    <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md shadow-sm sticky top-0 z-40">
+      <div className="max-w-7xl mx-auto px-6 py-4 flex justify-between items-center">
+        <div
+          className="flex items-center cursor-pointer"
+          onClick={() => navigate('/')}
+        >
+          <div className="h-9 w-9 bg-gradient-to-r from-indigo-600 to-purple-600 rounded-lg flex items-center justify-center shadow">
+            <span className="text-white font-bold text-md">M</span>
+          </div>
+          <span className="ml-3 text-lg font-semibold tracking-tight">MedSpaSync Pro</span>
+        </div>
+        <div className="relative flex items-center space-x-4">
+          <button
+            onClick={() => setDarkMode(!darkMode)}
+            className="text-sm px-3 py-1 border rounded-lg border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+            aria-label={`Switch to ${darkMode ? 'light' : 'dark'} mode`}
+          >
+            {darkMode ? '☀️ Light' : '🌙 Dark'}
+          </button>
+          {isAuthenticated ? (
+            <div className="relative">
+              <button
+                onClick={() => setMenuOpen((o) => !o)}
+                className="bg-indigo-600 text-white px-3 py-1 rounded-lg flex items-center"
+              >
+                {firstName ? `Hi, ${firstName}` : 'Account'}
+              </button>
+              {menuOpen && (
+                <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-800 rounded-lg shadow-lg py-2 z-50">
+                  <button
+                    onClick={() => { setMenuOpen(false); navigate('/profile'); }}
+                    className="block w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    Profile
+                  </button>
+                  <button
+                    onClick={handleLogout}
+                    className="block w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    Logout
+                  </button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <>
+              <button
+                onClick={() => navigate('/login')}
+                className="text-gray-700 dark:text-gray-200 hover:text-indigo-600 transition font-medium"
+              >
+                Sign In
+              </button>
+              <button
+                onClick={() => navigate('/register')}
+                className="bg-indigo-600 hover:bg-indigo-700 text-white px-5 py-2 rounded-lg shadow transition"
+              >
+                Register
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default TopNav;

--- a/src/pages/AppointmentsPage.jsx
+++ b/src/pages/AppointmentsPage.jsx
@@ -4,6 +4,8 @@
 // ========================================
 
 import React, { useState, useMemo, useCallback } from 'react';
+import TopNav from '../components/TopNav.jsx';
+import { useAuth } from '../services/AuthContext.jsx';
 import { Calendar, Plus, Search, Users, Phone, Mail, Clock, User, DollarSign, MoreVertical } from 'lucide-react';
 import { 
   useAppointments, 
@@ -331,6 +333,7 @@ const AppointmentFormModal = React.memo(({ appointment, isOpen, onClose, onSubmi
 // Main Appointments Page
 const AppointmentsPage = React.memo(() => {
   const [statusFilter, setStatusFilter] = useState('all');
+  const { firstName, practiceName } = useAuth();
   const [dateFilter, setDateFilter] = useState('all');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -443,11 +446,14 @@ const AppointmentsPage = React.memo(() => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50/30 p-6">
+      <TopNav />
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900">Appointments</h1>
+            <h1 className="text-3xl font-bold text-gray-900">
+              {practiceName ? `Appointments for ${practiceName}` : 'Appointments'}
+            </h1>
             <p className="text-gray-600 mt-1">Manage your appointment schedule</p>
           </div>
           <button 

--- a/src/pages/ClientsPage.jsx
+++ b/src/pages/ClientsPage.jsx
@@ -1,5 +1,7 @@
 // src/pages/ClientsPage.jsx
 import React, { useState, useMemo, useCallback } from 'react';
+import TopNav from '../components/TopNav.jsx';
+import { useAuth } from '../services/AuthContext.jsx';
 import { Plus, Search, Users } from 'lucide-react'; // Removed unused icons (Phone, Mail, Calendar, MoreVertical, Edit, Trash2)
 import { 
   useClients, 
@@ -20,6 +22,7 @@ import { useDebounce } from '../hooks/useDebounce.js'; // Use the useDebounce ho
 // Main Clients Page Component
 const ClientsPage = React.memo(() => {
   const [searchQuery, setSearchQuery] = useState('');
+  const { firstName } = useAuth();
   const [statusFilter, setStatusFilter] = useState('all');
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize] = useState(12); // Clients per page
@@ -137,11 +140,14 @@ const ClientsPage = React.memo(() => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50/30 p-6">
+      <TopNav />
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <div className="flex justify-between items-center mb-8">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900">Client Management</h1>
+            <h1 className="text-3xl font-bold text-gray-900">
+              {firstName ? `${firstName}'s Clients` : 'Client Management'}
+            </h1>
             <p className="text-gray-600 mt-1">Manage your spa's client relationships</p>
           </div>
           <button 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -11,6 +11,7 @@ import ClientCard from '../components/ClientCard.jsx';
 import { format, startOfWeek, endOfWeek, startOfMonth, endOfMonth } from 'date-fns';
 import { formatCurrency } from '../utils/formatting.js';
 import { Link } from 'react-router-dom';
+import TopNav from '../components/TopNav.jsx';
 
 // Metric Card Component
 const MetricCard = ({ title, value, change, trend, icon: Icon, gradient, isLoading, onClick }) => (
@@ -164,7 +165,7 @@ const TopClients = ({ clients, isLoading }) => {
 
 // Main Dashboard Component
 const Dashboard = () => {
-  const { user } = useAuth();
+  const { firstName } = useAuth();
   const [dateRange, setDateRange] = useState('week');
   
   // Calculate date ranges
@@ -225,13 +226,14 @@ const Dashboard = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50/30">
+      <TopNav />
       <div className="max-w-7xl mx-auto p-6">
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-3xl font-bold text-gray-900">
-                Welcome back, {user?.firstName}! 👋
+                {firstName ? `Welcome back, ${firstName}! 👋` : 'Welcome back!'}
               </h1>
               <p className="text-gray-600 mt-1">Here's what's happening at your spa today.</p>
             </div>

--- a/src/pages/ServicesPage.jsx
+++ b/src/pages/ServicesPage.jsx
@@ -1,9 +1,11 @@
 // src/pages/ServicesPage.jsx
 import React from 'react';
+import TopNav from '../components/TopNav.jsx';
 
 const ServicesPage = () => {
   return (
     <div className="min-h-screen bg-gray-50 py-12">
+      <TopNav />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Hero Section */}
         <div className="text-center mb-16">

--- a/src/services/AuthContext.jsx
+++ b/src/services/AuthContext.jsx
@@ -8,6 +8,7 @@ const AuthContext = createContext(null);
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(() => storageService.getUserData());
+  const [firstName, setFirstName] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -32,6 +33,21 @@ export const AuthProvider = ({ children }) => {
   useEffect(() => {
     initialize();
   }, [initialize]);
+
+  // Derive first name from user data or token
+  useEffect(() => {
+    let name = '';
+    if (user?.firstName) {
+      name = user.firstName;
+    } else if (user?.name) {
+      name = user.name.split(' ')[0];
+    } else {
+      const token = storageService.getAuthToken();
+      const decoded = decodeJWT(token);
+      name = decoded?.given_name || decoded?.name?.split(' ')[0] || '';
+    }
+    setFirstName(name);
+  }, [user]);
 
   const login = async (credentials) => {
     setError(null);
@@ -134,7 +150,9 @@ export const AuthProvider = ({ children }) => {
         isAuthenticated: !!user,
         role: user?.role,
         practiceId: user?.practiceId,
-        subscriptionTier: user?.subscriptionTier || 'starter'
+        subscriptionTier: user?.subscriptionTier || 'starter',
+        firstName,
+        practiceName: user?.practiceName || user?.practice?.name
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- extract `firstName` in `AuthContext` and expose in context value
- create `TopNav` component with auth-aware menu and dark mode toggle
- use `TopNav` across pages and greet users by first name
- update landing page redirects and remove page-specific dark mode state
- personalize headings on clients and appointments pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848fad7625483329667c33608dfcc55