### PR TITLE
Improve token handling on load

### DIFF
--- a/src/services/AuthContext.jsx
+++ b/src/services/AuthContext.jsx
@@ -18,6 +18,31 @@ export const AuthProvider = ({ children }) => {
       setIsLoading(false);
       return;
     }
+
+    const decoded = decodeJWT(token);
+    const now = Date.now() / 1000;
+    if (decoded?.exp && decoded.exp - now < 120) {
+      try {
+        const newToken = await authService.refreshToken();
+        storageService.setAuthToken(newToken.token || newToken);
+      } catch {
+        storageService.clearAll();
+        setUser(null);
+        setIsLoading(false);
+        return;
+      }
+    } else if (decoded?.exp && decoded.exp <= now) {
+      try {
+        const newToken = await authService.refreshToken();
+        storageService.setAuthToken(newToken.token || newToken);
+      } catch {
+        storageService.clearAll();
+        setUser(null);
+        setIsLoading(false);
+        return;
+      }
+    }
+
     try {
       const res = await authService.getProfile();
       setUser(res.user);


### PR DESCRIPTION
## Summary
- refresh access token during initialization if nearly expired
- log out if token expired and refresh fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848ff2f010c8332b5790421d4a2741b