### PR TITLE
Fix duplicate PublicRoute import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,8 +2,8 @@ import { lazy, Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { useAuth } from './services/AuthContext.jsx';
 import PublicRoute from './components/auth/PublicRoute.jsx';
-import PublicRoute from './components/Auth/PublicRoute.jsx';
-import Toast from './components/Common/Toast.jsx';
+import LoadingScreen from './components/Common/LoadingScreen.jsx';
+import Toast from './components/Ui/Toast.jsx';
 
 import LandingPage from './pages/LandingPage.jsx';
 import LoginPage from './pages/LoginPage.jsx';


### PR DESCRIPTION
## Summary
- remove extra import of `PublicRoute`
- import `LoadingScreen` component and fix `Toast` path

## Testing
- `npm run build` *(fails: Could not resolve "./pages/SupportPage.jsx")*

------
https://chatgpt.com/codex/tasks/task_e_68490417ef1c8332a9a7b56a3bfe358f