### PR TITLE
Add Reconciliation timeline component

### DIFF
--- a/src/components/ReconciliationTimeline.jsx
+++ b/src/components/ReconciliationTimeline.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Circle, FileText } from 'lucide-react';
+import { format } from 'date-fns';
+import { useReconciliationHistory } from '../services/ReconciliationHistoryContext.jsx';
+
+const ReconciliationTimeline = ({ history }) => {
+  const contextHistory = useReconciliationHistory();
+  const items = history || contextHistory || [];
+
+  if (!items.length) {
+    return <p className="text-sm text-gray-500">No reconciliation history.</p>;
+  }
+
+  return (
+    <ol className="relative border-l border-gray-300 dark:border-gray-700">
+      {items.map((item, idx) => (
+        <li key={idx} className="mb-8 ml-6">
+          <span className="absolute -left-3 flex items-center justify-center w-6 h-6 bg-blue-600 rounded-full ring-8 ring-white dark:ring-gray-900">
+            <Circle className="w-3 h-3 text-white" fill="currentColor" />
+          </span>
+          <h3 className="flex flex-col sm:flex-row sm:items-center mb-1 text-lg font-semibold text-gray-900">
+            {format(new Date(item.date), 'PPP')}
+            <span className="sm:ml-3 text-sm font-medium text-blue-600">{item.matchRate}% match</span>
+          </h3>
+          <p className="text-sm text-gray-500 flex items-center">
+            <FileText className="w-4 h-4 mr-1" />{item.fileType}
+          </p>
+        </li>
+      ))}
+    </ol>
+  );
+};
+
+export default ReconciliationTimeline;

--- a/src/services/ReconciliationHistoryContext.jsx
+++ b/src/services/ReconciliationHistoryContext.jsx
@@ -1,0 +1,13 @@
+import React, { createContext, useContext } from 'react';
+
+const ReconciliationHistoryContext = createContext([]);
+
+export const ReconciliationHistoryProvider = ({ history = [], children }) => (
+  <ReconciliationHistoryContext.Provider value={history}>
+    {children}
+  </ReconciliationHistoryContext.Provider>
+);
+
+export const useReconciliationHistory = () => useContext(ReconciliationHistoryContext);
+
+export default ReconciliationHistoryContext;


### PR DESCRIPTION
## Summary
- create `ReconciliationTimeline` component for showing past reconciliations
- add `ReconciliationHistoryContext` for context-based history access

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684a4428c7b48332b350c576d4a96b4e