### PR TITLE
Add SubscriptionPlan with Stripe checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@eslint/js": "^9.28.0",
         "@tanstack/react-query-devtools": "^5.80.6",
+        "@testing-library/react": "^16.3.0",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
@@ -1220,6 +1221,101 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/chai": {
       "version": "4.3.20",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
@@ -1852,6 +1948,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -2863,6 +2970,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2924,6 +3042,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5330,6 +5456,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@eslint/js": "^9.28.0",
     "@tanstack/react-query-devtools": "^5.80.6",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "@typescript-eslint/eslint-plugin": "^5.53.0",

--- a/src/components/SubscriptionPlan.jsx
+++ b/src/components/SubscriptionPlan.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import api from '../services/api.js';
+import { useAuth } from '../services/AuthContext.jsx';
+
+const SubscriptionPlan = () => {
+  const { subscriptionTier, refreshUser } = useAuth();
+  const location = useLocation();
+  const [loading, setLoading] = useState(false);
+  const [showBanner, setShowBanner] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get('session_id')) {
+      (async () => {
+        try {
+          await refreshUser();
+          setShowBanner(true);
+        } catch (err) {
+          console.error(err);
+        }
+      })();
+    }
+  }, [location.search, refreshUser]);
+
+  const handleUpgrade = async () => {
+    setLoading(true);
+    try {
+      const res = await api.post('/checkout/create-session', { tier: 'professional' });
+      window.location.href = res.data.url;
+    } catch (err) {
+      toast.error(err.response?.data?.message || 'Checkout failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 bg-white rounded-lg shadow">
+      {showBanner && (
+        <div className="mb-4 p-3 rounded bg-green-100 text-green-800" data-testid="success-banner">
+          Plan upgraded successfully!
+        </div>
+      )}
+      <p className="mb-4">
+        Current Plan: <span className="font-semibold capitalize">{subscriptionTier}</span>
+      </p>
+      <button
+        onClick={handleUpgrade}
+        disabled={loading || subscriptionTier === 'professional'}
+        className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 disabled:opacity-50"
+      >
+        {loading ? 'Loading...' : 'Upgrade to Professional'}
+      </button>
+    </div>
+  );
+};
+
+export default SubscriptionPlan;

--- a/src/components/__tests__/SubscriptionPlan.test.jsx
+++ b/src/components/__tests__/SubscriptionPlan.test.jsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SubscriptionPlan from '../SubscriptionPlan.jsx';
+import api from '../../services/api.js';
+import { useAuth } from '../../services/AuthContext.jsx';
+
+vi.mock('../../services/api.js', () => ({
+  default: { post: vi.fn() }
+}));
+
+vi.mock('../../services/AuthContext.jsx', () => ({
+  useAuth: vi.fn()
+}));
+
+describe('SubscriptionPlan', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    useAuth.mockReturnValue({ subscriptionTier: 'core', refreshUser: vi.fn() });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('displays current plan', () => {
+    render(
+      <MemoryRouter>
+        <SubscriptionPlan />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/current plan/i).textContent).toMatch(/Core/i);
+  });
+
+  it('starts checkout on upgrade click', async () => {
+    api.post.mockResolvedValue({ data: { url: 'https://stripe.test' } });
+    delete window.location;
+    window.location = { href: '' };
+
+    render(
+      <MemoryRouter>
+        <SubscriptionPlan />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /upgrade to professional/i }));
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith('/checkout/create-session', { tier: 'professional' }));
+    expect(window.location.href).toBe('https://stripe.test');
+  });
+
+  it('refreshes auth and shows banner when session_id present', async () => {
+    const refreshUser = vi.fn();
+    useAuth.mockReturnValue({ subscriptionTier: 'core', refreshUser });
+    render(
+      <MemoryRouter initialEntries={['/?session_id=123']}>
+        <SubscriptionPlan />
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(refreshUser).toHaveBeenCalled());
+    expect(screen.queryByTestId('success-banner')).not.toBeNull();
+  });
+});

--- a/src/services/AuthContext.jsx
+++ b/src/services/AuthContext.jsx
@@ -125,6 +125,16 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
+  const refreshUser = async () => {
+    try {
+      const res = await authService.getProfile();
+      setUser(res.user);
+      storageService.updateLastActivity();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   // Track user activity and session validity
   useEffect(() => {
     const activityEvents = ['mousemove', 'mousedown', 'keydown', 'touchstart'];
@@ -171,6 +181,7 @@ export const AuthProvider = ({ children }) => {
         logout,
         clearError,
         refreshToken,
+        refreshUser,
         error,
         isAuthenticated: !!user,
         role: user?.role,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react({ fastRefresh: false })],
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- add `SubscriptionPlan` component to handle plan upgrade with Stripe Checkout
- expose `refreshUser` in `AuthContext` so components can refresh profile
- add tests for the new component
- configure Vitest for React and add `@testing-library/react`

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a43a8c0448332a7edaa54f5e6ed4f