### PR TITLE
Add AI flagging toggle with confidence table

### DIFF
--- a/src/components/MatchTable.jsx
+++ b/src/components/MatchTable.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import clsx from 'clsx';
+
+const colorForScore = (score) => {
+  if (score >= 0.8) return 'text-green-600';
+  if (score >= 0.5) return 'text-yellow-600';
+  return 'text-red-600';
+};
+
+const MatchTable = ({ data = [] }) => (
+  <div className="overflow-x-auto">
+    <table className="min-w-full text-sm">
+      <thead className="bg-gray-50">
+        <tr>
+          <th className="px-4 py-2 text-left">POS</th>
+          <th className="px-4 py-2 text-left">Alle</th>
+          <th className="px-4 py-2 text-left">Aspire</th>
+          <th className="px-4 py-2 text-left">Confidence</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-gray-200">
+        {data.map((row, idx) => (
+          <tr
+            key={idx}
+            className={clsx(row.flagged && 'bg-orange-50')}
+          >
+            <td className="px-4 py-2">{row.pos || '-'}</td>
+            <td className="px-4 py-2">{row.alle || '-'}</td>
+            <td className="px-4 py-2">{row.aspire || '-'}</td>
+            <td className="px-4 py-2">
+              <span
+                className={clsx(colorForScore(row.matchConfidence), 'font-medium')}
+                title={`Score: ${row.matchConfidence}`}
+              >
+                {row.matchConfidence !== undefined
+                  ? `${Math.round(row.matchConfidence * 100)}%`
+                  : '-'}
+              </span>
+              {row.flagged && (
+                <AlertTriangle
+                  className="inline ml-1 text-orange-600 w-4 h-4"
+                  title="AI flagged anomaly"
+                />
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default MatchTable;

--- a/src/services/ai.js
+++ b/src/services/ai.js
@@ -1,0 +1,11 @@
+import api from './api.js';
+
+export async function callAIFlagging(records = []) {
+  try {
+    const res = await api.post('/ai/flag-anomaly', { records });
+    return res.data;
+  } catch (err) {
+    console.error('AI flagging failed:', err);
+    return records;
+  }
+}


### PR DESCRIPTION
## Summary
- add AI flagging service helper
- create new `MatchTable` for displaying results with confidence column
- extend `ReconciliationRunner` with toggle to enable AI flagging and table output

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a67b65f1c83329b13b8c2674804c8