### PR TITLE
Fix docs and support links

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,10 @@ npm run build
 ## 📞 Support
 
 For questions or issues:
-1. Check the documentation
+1. [Check the documentation](/docs)
 2. Search existing issues
 3. Create a new issue with details
-4. Contact support team
+4. [Contact support team](/support)
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary
- wire up docs and support links in the README

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a6d475f4483328ba8a4bed9e57565