### PR TITLE
Fix Vite base path for GH Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -26,5 +26,5 @@ export default defineConfig({
   define: {
     'process.env': process.env
   },
-  base: '/'
+  base: '/medspasync-frontend/'
 });


### PR DESCRIPTION
## Summary
- fix routing by setting correct `base` path for GitHub Pages in `vite.config.js`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a734562348332b2358a5c476518ba