### PR TITLE
Fix Vite base path for GH Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ npm run build
 # Upload dist folder to Netlify
 ```
 
+### Deploy to GitHub Pages
+```bash
+npm run build
+npm run deploy
+```
+
 ## 📞 Support
 
 For questions or issues:

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,5 +26,5 @@ export default defineConfig({
   define: {
     'process.env': process.env
   },
-  base: '/'
+  base: process.env.NODE_ENV === 'production' ? '/medspasync-frontend/' : '/'
 });


### PR DESCRIPTION
## Summary
- fix routing by setting correct `base` path for GitHub Pages in `vite.config.js`
- document GitHub Pages deployment instructions

## Testing
- `npx vitest run --silent`


------
https://chatgpt.com/codex/tasks/task_e_684a734562348332b2358a5c476518ba