### PR TITLE
Fix 404 by making Vite base path configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Example environment file
 VITE_API_BASE_URL=http://localhost:5000
+# Set this to "/medspasync-frontend/" when deploying to GitHub Pages
+VITE_BASE_PATH=

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ npm run build
 ```
 
 ### Deploy to GitHub Pages
+Set `VITE_BASE_PATH=/medspasync-frontend/` before building:
+
 ```bash
 npm run build
 npm run deploy

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,9 @@ function stripUseClient() {
   };
 }
 
+const basePath = process.env.VITE_BASE_PATH ||
+  (process.env.NODE_ENV === 'production' ? '/medspasync-frontend/' : '/');
+
 export default defineConfig({
   plugins: [react(), stripUseClient(), visualizer()],
   build: {
@@ -25,5 +28,5 @@ export default defineConfig({
   define: {
     'process.env': process.env
   },
-  base: process.env.NODE_ENV === 'production' ? '/medspasync-frontend/' : '/',
+  base: basePath,
 });


### PR DESCRIPTION
## Summary
- allow overriding the Vite `base` option with `VITE_BASE_PATH`
- document GitHub Pages deployment and new env var
- update `.env.example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a8010a8848332b68d9be13cc7de7a