### PR TITLE
Finalize Netlify config and add 404 fallback

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="MedSpaSync Pro - Medical Spa Management Platform" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    
+    <title>MedSpaSync Pro - Medical Spa Management Platform</title>
+  </head>
+  <body>
+    <script>
+      if (
+        localStorage.getItem('darkMode') === 'true' ||
+        (!localStorage.getItem('darkMode') &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches)
+      ) {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <div id="modal-root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/__tests__/404.test.js
+++ b/__tests__/404.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('404.html', () => {
+  it('exists in project root and matches index.html content', () => {
+    const root = path.resolve(__dirname, '..');
+    const indexPath = path.join(root, 'index.html');
+    const notFoundPath = path.join(root, '404.html');
+
+    expect(fs.existsSync(notFoundPath)).toBe(true);
+
+    const indexHtml = fs.readFileSync(indexPath, 'utf8');
+    const notFoundHtml = fs.readFileSync(notFoundPath, 'utf8');
+    expect(notFoundHtml.trim()).toBe(indexHtml.trim());
+  });
+});

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="MedSpaSync Pro - Medical Spa Management Platform" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    
+    <title>MedSpaSync Pro - Medical Spa Management Platform</title>
+  </head>
+  <body>
+    <script>
+      if (
+        localStorage.getItem('darkMode') === 'true' ||
+        (!localStorage.getItem('darkMode') &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches)
+      ) {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <div id="modal-root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/src/pages/ClientsPage.jsx
+++ b/src/pages/ClientsPage.jsx
@@ -93,7 +93,6 @@ const ClientsPage = React.memo(() => {
 
   const handleViewClient = useCallback((client) => {
     // Implement client detail view (e.g., open a modal, navigate to /clients/:id)
-    console.log('Viewing client:', client);
     toast.info(`View Client: ${client.firstName} ${client.lastName}`);
   }, []);
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,8 +16,7 @@ function stripUseClient() {
   };
 }
 
-const basePath = process.env.VITE_BASE_PATH ||
-  (process.env.NODE_ENV === 'production' ? '/medspasync-frontend/' : '/');
+const basePath = process.env.VITE_BASE_PATH || '/';
 
 export default defineConfig({
   plugins: [react(), stripUseClient(), visualizer()],


### PR DESCRIPTION
## Summary
- ensure Netlify build config in vite and netlify.toml
- add 404.html fallback for SPA routing
- copy 404 page to public for build output
- remove stray console.log in Clients page
- include unit test to verify 404.html exists

## Testing
- `npm run test --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a8d41d460833291e9595033656b5e