### PR TITLE
Add AI reconciliation review interface

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,24 +1,8 @@
-import { lazy, Suspense } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import React from 'react';
 import { useAuth } from './services/AuthContext.jsx';
-import PublicRoute from './components/auth/PublicRoute.jsx';
-import ProtectedRoute from './components/auth/ProtectedRoute.jsx';
 import LoadingScreen from './components/Common/LoadingScreen.jsx';
 import Toast from './components/Ui/Toast.jsx';
-
-import LandingPage from './pages/LandingPage.jsx';
-import LoginPage from './pages/LoginPage.jsx';
-import RegisterPage from './pages/RegisterPage.jsx';
-import SupportPage from './pages/SupportPage.jsx';
-import DocsPage from './pages/DocsPage.jsx';
-import NotFoundPage from './pages/NotFoundPage.jsx';
-
-const DashboardPage = lazy(() => import('./pages/Dashboard.jsx'));
-const ClientsPage = lazy(() => import('./pages/ClientsPage.jsx'));
-const AppointmentsPage = lazy(() => import('./pages/AppointmentsPage.jsx'));
-const ServicesPage = lazy(() => import('./pages/ServicesPage.jsx'));
-const DemoReconciliation = lazy(() => import('./pages/DemoReconciliation.jsx'));
-const ReconciliationRunner = lazy(() => import('./components/ReconciliationRunner.jsx'));
+import AppRoutes from './routes.jsx';
 
 function AppContent() {
   const { isLoading } = useAuth();
@@ -30,66 +14,7 @@ function AppContent() {
   return (
     <div className="App min-h-screen bg-gray-50">
       <Toast />
-      <Routes>
-        {/* Public Routes */}
-        <Route path="/" element={<PublicRoute><LandingPage /></PublicRoute>} />
-        <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
-        <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
-        <Route path="/support" element={<PublicRoute><SupportPage /></PublicRoute>} />
-        <Route path="/docs" element={<PublicRoute><DocsPage /></PublicRoute>} />
-        <Route
-          path="/demo"
-          element={
-            <PublicRoute>
-              <Suspense fallback={<LoadingScreen />}>
-                <DemoReconciliation />
-              </Suspense>
-            </PublicRoute>
-          }
-        />
-        <Route
-          path="/dashboard"
-          element={
-            <ProtectedRoute>
-              <Suspense fallback={<LoadingScreen />}>
-                <DashboardPage />
-              </Suspense>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/clients"
-          element={
-            <ProtectedRoute>
-              <Suspense fallback={<LoadingScreen />}>
-                <ClientsPage />
-              </Suspense>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/appointments"
-          element={
-            <ProtectedRoute>
-              <Suspense fallback={<LoadingScreen />}>
-                <AppointmentsPage />
-              </Suspense>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/services"
-          element={
-            <ProtectedRoute>
-              <Suspense fallback={<LoadingScreen />}>
-                <ServicesPage />
-              </Suspense>
-            </ProtectedRoute>
-          }
-        />
-        <Route path="*" element={<NotFoundPage />} />
-        {/* Additional authenticated/private routes can be added below */}
-      </Routes>
+      <AppRoutes />
     </div>
   );
 }

--- a/src/components/AIPipeline/ConfidenceScore.jsx
+++ b/src/components/AIPipeline/ConfidenceScore.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const gradient = (score) => {
+  if (score >= 0.8) return 'bg-green-500';
+  if (score >= 0.5) return 'bg-yellow-500';
+  return 'bg-red-500';
+};
+
+const ConfidenceScore = ({ score = 0 }) => (
+  <div className="w-24 text-right">
+    <div className="w-full h-2 bg-gray-200 rounded">
+      <div
+        className={`${gradient(score)} h-2 rounded`}
+        style={{ width: `${Math.round(score * 100)}%` }}
+      />
+    </div>
+    <span className="text-xs text-gray-600">{Math.round(score * 100)}%</span>
+  </div>
+);
+
+export default ConfidenceScore;

--- a/src/components/AIPipeline/JsonViewer.jsx
+++ b/src/components/AIPipeline/JsonViewer.jsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+
+const JsonViewer = ({ data, label }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="my-2">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="text-indigo-600 text-sm mb-1"
+      >
+        {open ? 'Hide' : 'Show'} {label}
+      </button>
+      {open && (
+        <pre className="bg-gray-100 p-2 rounded text-xs overflow-auto max-h-60">
+          {JSON.stringify(data, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+};
+
+export default JsonViewer;

--- a/src/components/AIPipeline/MatchCard.jsx
+++ b/src/components/AIPipeline/MatchCard.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ConfidenceScore from './ConfidenceScore.jsx';
+
+const MatchCard = ({ match, onClick }) => (
+  <div
+    onClick={onClick}
+    className="bg-white rounded-lg shadow border p-4 hover:bg-gray-50 cursor-pointer"
+  >
+    <div className="flex justify-between items-center">
+      <div>
+        <p className="font-semibold text-gray-800">POS: {match.pos}</p>
+        <p className="text-sm text-gray-500">Alle: {match.alle}</p>
+        <p className="text-sm text-gray-500">Aspire: {match.aspire}</p>
+      </div>
+      <ConfidenceScore score={match.confidence} />
+    </div>
+  </div>
+);
+
+export default MatchCard;

--- a/src/components/AIPipeline/TrainModelModal.jsx
+++ b/src/components/AIPipeline/TrainModelModal.jsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import Modal from '../Ui/Modal.jsx';
+
+const TrainModelModal = ({ isOpen, onClose, onSubmit }) => {
+  const [text, setText] = useState('');
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Submit Correction">
+      <div className="space-y-4">
+        <p className="text-sm text-gray-600">Confirm that the displayed records match or provide corrections below.</p>
+        <textarea
+          className="w-full border rounded p-2"
+          rows="4"
+          value={text}
+          placeholder="Provide feedback or corrections here..."
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button
+          onClick={() => onSubmit(text)}
+          className="bg-indigo-600 text-white px-4 py-2 rounded"
+        >
+          Submit
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default TrainModelModal;

--- a/src/mock/aiMatchDetails.js
+++ b/src/mock/aiMatchDetails.js
@@ -1,0 +1,42 @@
+export const aiMatchDetails = {
+  1: {
+    id: 1,
+    confidence: 0.82,
+    posRecord: { id: 101, name: 'Jane Doe', email: 'jane@pos.com' },
+    alleRecord: { id: 201, name: 'Jane D.', email: 'jane@alle.com' },
+    aspireRecord: { id: 301, name: 'Jane A. Doe', email: 'jane@aspire.com' },
+    audit: [{ action: 'created', user: 'system', date: '2024-05-01' }]
+  },
+  2: {
+    id: 2,
+    confidence: 0.59,
+    posRecord: { id: 102, name: 'Mary Smith' },
+    alleRecord: { id: 202, name: 'M. Smith' },
+    aspireRecord: { id: 302, name: 'Mary S' },
+    audit: [{ action: 'flagged', user: 'system', date: '2024-05-02' }]
+  },
+  3: {
+    id: 3,
+    confidence: 0.4,
+    posRecord: { id: 103, name: 'John Brown' },
+    alleRecord: { id: 203, name: 'J. Brown' },
+    aspireRecord: { id: 303, name: 'Jon Brow' },
+    audit: [{ action: 'flagged', user: 'system', date: '2024-05-03' }]
+  },
+  4: {
+    id: 4,
+    confidence: 0.76,
+    posRecord: { id: 104, name: 'Chris Green' },
+    alleRecord: { id: 204, name: 'Christopher Green' },
+    aspireRecord: { id: 304, name: 'Chris G.' },
+    audit: [{ action: 'created', user: 'system', date: '2024-05-04' }]
+  },
+  5: {
+    id: 5,
+    confidence: 0.65,
+    posRecord: { id: 105, name: 'Pat Johnson' },
+    alleRecord: { id: 205, name: 'Pat J.' },
+    aspireRecord: { id: 305, name: 'Patrick Johnson' },
+    audit: [{ action: 'flagged', user: 'system', date: '2024-05-05' }]
+  }
+};

--- a/src/mock/aiMatches.json
+++ b/src/mock/aiMatches.json
@@ -1,0 +1,7 @@
+[
+  { "id": 1, "pos": "Jane Doe", "alle": "Jane D.", "aspire": "Jane A. Doe", "confidence": 0.82, "flagged": true },
+  { "id": 2, "pos": "Mary Smith", "alle": "M. Smith", "aspire": "Mary S", "confidence": 0.59, "flagged": true },
+  { "id": 3, "pos": "John Brown", "alle": "J. Brown", "aspire": "Jon Brow", "confidence": 0.4, "flagged": true },
+  { "id": 4, "pos": "Chris Green", "alle": "Christopher Green", "aspire": "Chris G.", "confidence": 0.76, "flagged": true },
+  { "id": 5, "pos": "Pat Johnson", "alle": "Pat J.", "aspire": "Patrick Johnson", "confidence": 0.65, "flagged": true }
+]

--- a/src/pages/ReconciliationAI/CorrectionForm.jsx
+++ b/src/pages/ReconciliationAI/CorrectionForm.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import toast from 'react-hot-toast';
+import TrainModelModal from '../../components/AIPipeline/TrainModelModal.jsx';
+
+const CorrectionForm = ({ matchId }) => {
+  const [open, setOpen] = useState(false);
+
+  const handleSubmit = async (text) => {
+    setOpen(false);
+    await fetch('/api/ai/train', { method: 'POST', body: JSON.stringify({ id: matchId, feedback: text }) });
+    toast.success('Feedback submitted');
+  };
+
+  return (
+    <div>
+      <button
+        onClick={() => setOpen(true)}
+        className="bg-indigo-600 text-white px-4 py-2 rounded"
+      >
+        Submit Correction
+      </button>
+      <TrainModelModal isOpen={open} onClose={() => setOpen(false)} onSubmit={handleSubmit} />
+    </div>
+  );
+};
+
+export default CorrectionForm;

--- a/src/pages/ReconciliationAI/MatchDetails.jsx
+++ b/src/pages/ReconciliationAI/MatchDetails.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import JsonViewer from '../../components/AIPipeline/JsonViewer.jsx';
+import ConfidenceScore from '../../components/AIPipeline/ConfidenceScore.jsx';
+import CorrectionForm from './CorrectionForm.jsx';
+import TierGuard from '../../components/auth/TierGuard.jsx';
+
+const MatchDetails = () => {
+  const { id } = useParams();
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    const url = new URL(`../../mock/aiMatchDetails.js`, import.meta.url);
+    import(url).then((module) => {
+      setData(module.aiMatchDetails[id]);
+    });
+  }, [id]);
+
+  if (!data) return <div className="p-6">Loading...</div>;
+
+  return (
+    <TierGuard allowedTiers={['professional']}>
+      <div className="max-w-3xl mx-auto p-6 space-y-4">
+        <h1 className="text-2xl font-bold">Match #{id}</h1>
+        <ConfidenceScore score={data.confidence} />
+        <JsonViewer data={data.posRecord} label="POS Record" />
+        <JsonViewer data={data.alleRecord} label="Alle Record" />
+        <JsonViewer data={data.aspireRecord} label="Aspire Record" />
+        <JsonViewer data={data.audit} label="Audit Trail" />
+        <CorrectionForm matchId={id} />
+      </div>
+    </TierGuard>
+  );
+};
+
+export default MatchDetails;

--- a/src/pages/ReconciliationAI/ReviewDashboard.jsx
+++ b/src/pages/ReconciliationAI/ReviewDashboard.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAI } from '../../services/AIContext.jsx';
+import MatchCard from '../../components/AIPipeline/MatchCard.jsx';
+import TierGuard from '../../components/auth/TierGuard.jsx';
+
+const ReviewDashboard = () => {
+  const { matches, loading } = useAI();
+  const navigate = useNavigate();
+
+  if (loading) {
+    return <div className="p-6">Loading matches...</div>;
+  }
+
+  return (
+    <TierGuard allowedTiers={['professional']}>
+      <div className="max-w-4xl mx-auto p-6 space-y-4">
+        <h1 className="text-2xl font-bold">AI Matches Needing Review</h1>
+        {matches.map((m) => (
+          <MatchCard key={m.id} match={m} onClick={() => navigate(`/ai-review/${m.id}`)} />
+        ))}
+      </div>
+    </TierGuard>
+  );
+};
+
+export default ReviewDashboard;

--- a/src/pages/ReconciliationAI/index.jsx
+++ b/src/pages/ReconciliationAI/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { AIProvider } from '../../services/AIContext.jsx';
+import ReviewDashboard from './ReviewDashboard.jsx';
+
+const ReconciliationAI = () => (
+  <AIProvider>
+    <ReviewDashboard />
+  </AIProvider>
+);
+
+export default ReconciliationAI;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,0 +1,105 @@
+import { lazy, Suspense } from 'react';
+import { Routes, Route } from 'react-router-dom';
+import PublicRoute from './components/auth/PublicRoute.jsx';
+import ProtectedRoute from './components/auth/ProtectedRoute.jsx';
+import TierGuard from './components/auth/TierGuard.jsx';
+import LoadingScreen from './components/Common/LoadingScreen.jsx';
+
+import LandingPage from './pages/LandingPage.jsx';
+import LoginPage from './pages/LoginPage.jsx';
+import RegisterPage from './pages/RegisterPage.jsx';
+import SupportPage from './pages/SupportPage.jsx';
+import DocsPage from './pages/DocsPage.jsx';
+import NotFoundPage from './pages/NotFoundPage.jsx';
+import ReconciliationAI from './pages/ReconciliationAI/index.jsx';
+import MatchDetails from './pages/ReconciliationAI/MatchDetails.jsx';
+
+const DashboardPage = lazy(() => import('./pages/Dashboard.jsx'));
+const ClientsPage = lazy(() => import('./pages/ClientsPage.jsx'));
+const AppointmentsPage = lazy(() => import('./pages/AppointmentsPage.jsx'));
+const ServicesPage = lazy(() => import('./pages/ServicesPage.jsx'));
+const DemoReconciliation = lazy(() => import('./pages/DemoReconciliation.jsx'));
+
+export default function AppRoutes() {
+  return (
+    <Routes>
+      {/* Public Routes */}
+      <Route path="/" element={<PublicRoute><LandingPage /></PublicRoute>} />
+      <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
+      <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
+      <Route path="/support" element={<PublicRoute><SupportPage /></PublicRoute>} />
+      <Route path="/docs" element={<PublicRoute><DocsPage /></PublicRoute>} />
+      <Route
+        path="/demo"
+        element={
+          <PublicRoute>
+            <Suspense fallback={<LoadingScreen />}>
+              <DemoReconciliation />
+            </Suspense>
+          </PublicRoute>
+        }
+      />
+      <Route
+        path="/dashboard"
+        element={
+          <ProtectedRoute>
+            <Suspense fallback={<LoadingScreen />}>
+              <DashboardPage />
+            </Suspense>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/clients"
+        element={
+          <ProtectedRoute>
+            <Suspense fallback={<LoadingScreen />}>
+              <ClientsPage />
+            </Suspense>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/appointments"
+        element={
+          <ProtectedRoute>
+            <Suspense fallback={<LoadingScreen />}>
+              <AppointmentsPage />
+            </Suspense>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/services"
+        element={
+          <ProtectedRoute>
+            <Suspense fallback={<LoadingScreen />}>
+              <ServicesPage />
+            </Suspense>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/ai-review"
+        element={
+          <ProtectedRoute requiredRoles={[ 'admin', 'staff' ]}>
+            <TierGuard allowedTiers={['professional']}>
+              <ReconciliationAI />
+            </TierGuard>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/ai-review/:id"
+        element={
+          <ProtectedRoute requiredRoles={[ 'admin', 'staff' ]}>
+            <TierGuard allowedTiers={['professional']}>
+              <MatchDetails />
+            </TierGuard>
+          </ProtectedRoute>
+        }
+      />
+      <Route path="*" element={<NotFoundPage />} />
+    </Routes>
+  );
+}

--- a/src/services/AIContext.jsx
+++ b/src/services/AIContext.jsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const AIContext = createContext({ matches: [] });
+
+export const AIProvider = ({ children }) => {
+  const [matches, setMatches] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const url = new URL('../mock/aiMatches.json', import.meta.url);
+    fetch(url)
+      .then((res) => res.json())
+      .then((data) => setMatches(data))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const refresh = () => {
+    setLoading(true);
+    const url = new URL('../mock/aiMatches.json', import.meta.url);
+    fetch(url)
+      .then((res) => res.json())
+      .then((data) => setMatches(data))
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <AIContext.Provider value={{ matches, loading, refresh }}>
+      {children}
+    </AIContext.Provider>
+  );
+};
+
+export const useAI = () => useContext(AIContext);


### PR DESCRIPTION
## Summary
- add `AIProvider` context and hooks for dummy match data
- create AI pipeline components (match card, confidence meter, JSON viewer, training modal)
- add new pages under ReconciliationAI with review dashboard, match details and correction form
- stub mock data for AI matches
- centralize routing in new `routes.jsx` with protected `/ai-review` routes
- update `App.jsx` to use new routes file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad77684a88332938501ef829657a8