### PR TITLE
Add API-powered AIContext with pagination and tests

### DIFF
--- a/__tests__/AIContext.test.jsx
+++ b/__tests__/AIContext.test.jsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test/utils.js';
+import { AIProvider, useAI } from '../src/services/AIContext.jsx';
+
+const TestComponent = () => {
+  const { matches, loading, error } = useAI();
+  if (loading) return <div>loading</div>;
+  if (error) return <div>{error}</div>;
+  return <div>count:{matches.length}</div>;
+};
+
+describe('AIContext', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches and renders ai matches', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ success: true, results: [{ id: 1 }], totalPages: 1 })
+    });
+
+    renderWithProviders(
+      <AIProvider>
+        <TestComponent />
+      </AIProvider>
+    );
+
+    expect(await screen.findByText('count:1')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith('/api/ai/matches?page=1&limit=50');
+  });
+
+  it('handles fetch errors', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network'));
+
+    renderWithProviders(
+      <AIProvider>
+        <TestComponent />
+      </AIProvider>
+    );
+
+    expect(await screen.findByText('Failed to load matches')).toBeInTheDocument();
+  });
+});

--- a/__tests__/CorrectionModal.test.jsx
+++ b/__tests__/CorrectionModal.test.jsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import CorrectionForm from '../src/pages/ReconciliationAI/CorrectionForm.jsx';
+
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn() } }));
+import toast from 'react-hot-toast';
+
+beforeEach(() => {
+  const modalRoot = document.createElement('div');
+  modalRoot.setAttribute('id', 'modal-root');
+  document.body.appendChild(modalRoot);
+});
+
+afterEach(() => {
+  document.getElementById('modal-root').remove();
+  vi.restoreAllMocks();
+});
+
+describe('Correction feedback flow', () => {
+  it('submits feedback and shows toast', async () => {
+    global.fetch = vi.fn().mockResolvedValue({});
+
+    render(<CorrectionForm matchId={1} />);
+
+    fireEvent.click(screen.getByText('Submit Correction'));
+    const textarea = await screen.findByPlaceholderText('Provide feedback or corrections here...');
+    fireEvent.change(textarea, { target: { value: 'great' } });
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/ai/train', expect.objectContaining({ method: 'POST' }));
+    expect(toast.success).toHaveBeenCalledWith('Feedback submitted');
+  });
+});

--- a/__tests__/ProtectedRoute.test.jsx
+++ b/__tests__/ProtectedRoute.test.jsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import ProtectedRoute from '../src/components/auth/ProtectedRoute.jsx';
+import TierGuard from '../src/components/auth/TierGuard.jsx';
+
+vi.mock('../src/services/AuthContext.jsx', () => ({
+  useAuth: vi.fn()
+}));
+
+const { useAuth } = require('../src/services/AuthContext.jsx');
+
+const Dummy = () => <div>AI review</div>;
+
+const renderRoute = () =>
+  render(
+    <MemoryRouter initialEntries={[ '/ai-review' ]}>
+      <Routes>
+        <Route
+          path="/ai-review"
+          element={
+            <ProtectedRoute requiredRoles={[ 'admin', 'staff' ]}>
+              <TierGuard allowedTiers={['professional']}>
+                <Dummy />
+              </TierGuard>
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/login" element={<div>Login</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('ProtectedRoute', () => {
+  it('redirects guests to login', () => {
+    useAuth.mockReturnValue({ isAuthenticated: false, isLoading: false, user: null });
+    const { container } = renderRoute();
+    expect(container.textContent).toBe('Login');
+  });
+
+  it('allows staff with professional tier', () => {
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      user: { role: 'staff', subscriptionTier: 'professional' }
+    });
+    const { container } = renderRoute();
+    expect(container.textContent).toBe('AI review');
+  });
+});

--- a/src/pages/ReconciliationAI/ReviewDashboard.jsx
+++ b/src/pages/ReconciliationAI/ReviewDashboard.jsx
@@ -5,7 +5,7 @@ import MatchCard from '../../components/AIPipeline/MatchCard.jsx';
 import TierGuard from '../../components/auth/TierGuard.jsx';
 
 const ReviewDashboard = () => {
-  const { matches, loading } = useAI();
+  const { matches, loading, page, totalPages, setPage } = useAI();
   const navigate = useNavigate();
 
   if (loading) {
@@ -19,6 +19,23 @@ const ReviewDashboard = () => {
         {matches.map((m) => (
           <MatchCard key={m.id} match={m} onClick={() => navigate(`/ai-review/${m.id}`)} />
         ))}
+        <div className="flex items-center justify-between pt-4">
+          <button
+            onClick={() => setPage(page - 1)}
+            disabled={page === 1}
+            className="px-3 py-1 rounded bg-gray-100 disabled:opacity-50"
+          >
+            Prev
+          </button>
+          <span className="text-sm">Page {page} of {totalPages}</span>
+          <button
+            onClick={() => setPage(page + 1)}
+            disabled={page === totalPages}
+            className="px-3 py-1 rounded bg-gray-100 disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
       </div>
     </TierGuard>
   );

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import { AuthProvider } from '../src/services/AuthContext.jsx';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export function renderWithProviders(ui) {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{ui}</AuthProvider>
+    </QueryClientProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch AI matches from `/api/ai/matches` with pagination
- expose pagination state via AIContext
- show page navigation in `ReviewDashboard`
- add utility `renderWithProviders` for tests
- test AIContext fetching, route protection and correction modal

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1087e7ac8332b9c5993988f4e9e2