### PR TITLE
Add AI reconciliation dashboard skeleton

### DIFF
--- a/src/components/reconciliation/ReconciliationDashboard.jsx
+++ b/src/components/reconciliation/ReconciliationDashboard.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import useReconciliation from '../../hooks/useReconciliation.js';
+import { useWebSocket } from '../../hooks/useWebSocket.js';
+
+const ReconciliationDashboard = () => {
+  const [dateRange, setDateRange] = useState({
+    start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    end: new Date()
+  });
+  const { startReconciliation, getResults, loading, error } = useReconciliation();
+  const { connectionStatus } = useWebSocket('/ws');
+  const [job, setJob] = useState(null);
+
+  const handleStart = async () => {
+    const jobInfo = await startReconciliation({ dateRange });
+    setJob(jobInfo);
+  };
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">AI Reconciliation</h1>
+      <div className="text-sm text-gray-600">WebSocket: {connectionStatus}</div>
+      <div className="space-x-2">
+        <input
+          type="date"
+          value={dateRange.start.toISOString().split('T')[0]}
+          onChange={e => setDateRange({ ...dateRange, start: new Date(e.target.value) })}
+        />
+        <input
+          type="date"
+          value={dateRange.end.toISOString().split('T')[0]}
+          onChange={e => setDateRange({ ...dateRange, end: new Date(e.target.value) })}
+        />
+        <button className="bg-blue-600 text-white px-4 py-1 rounded" onClick={handleStart} disabled={loading}>
+          {loading ? 'Starting...' : 'Start'}
+        </button>
+      </div>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      {job && (
+        <div className="text-sm text-gray-700">
+          Job ID: {job.jobId} Status: {job.status}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ReconciliationDashboard;

--- a/src/hooks/useReconciliation.js
+++ b/src/hooks/useReconciliation.js
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import reconciliationService from '../services/reconciliationService.js';
+
+export function useReconciliation() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const startReconciliation = async (options) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const job = await reconciliationService.startReconciliation(options);
+      return job;
+    } catch (err) {
+      setError(err.message || 'Failed to start reconciliation');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getResults = async (jobId) => {
+    try {
+      return await reconciliationService.getResults(jobId);
+    } catch (err) {
+      setError(err.message || 'Failed to fetch results');
+      throw err;
+    }
+  };
+
+  return { startReconciliation, getResults, loading, error };
+}
+
+export default useReconciliation;

--- a/src/pages/ReconciliationDashboard.jsx
+++ b/src/pages/ReconciliationDashboard.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReconciliationDashboard from '../components/reconciliation/ReconciliationDashboard.jsx';
+
+const ReconciliationPage = () => <ReconciliationDashboard />;
+
+export default ReconciliationPage;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -19,6 +19,7 @@ const ClientsPage = lazy(() => import('./pages/ClientsPage.jsx'));
 const AppointmentsPage = lazy(() => import('./pages/AppointmentsPage.jsx'));
 const ServicesPage = lazy(() => import('./pages/ServicesPage.jsx'));
 const DemoReconciliation = lazy(() => import('./pages/DemoReconciliation.jsx'));
+const ReconciliationDashboardPage = lazy(() => import('./pages/ReconciliationDashboard.jsx'));
 
 export default function AppRoutes() {
   return (
@@ -75,6 +76,16 @@ export default function AppRoutes() {
           <ProtectedRoute>
             <Suspense fallback={<LoadingScreen />}>
               <ServicesPage />
+            </Suspense>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/reconciliation-dashboard"
+        element={
+          <ProtectedRoute>
+            <Suspense fallback={<LoadingScreen />}>
+              <ReconciliationDashboardPage />
             </Suspense>
           </ProtectedRoute>
         }

--- a/src/services/reconciliationService.js
+++ b/src/services/reconciliationService.js
@@ -1,0 +1,23 @@
+import api from './api.js';
+
+const reconciliationService = {
+  startReconciliation: async (options) => {
+    const res = await api.post('/reconciliation/process', options);
+    return res.data;
+  },
+  getResults: async (jobId) => {
+    const res = await api.get(`/reconciliation/results/${jobId}`);
+    return res.data;
+  },
+  getDashboardMetrics: async (period = '30d') => {
+    const res = await api.get('/reconciliation/dashboard', { params: { period } });
+    return res.data;
+  },
+  submitManualReview: async (data) => {
+    const res = await api.post('/reconciliation/manual-review', data);
+    return res.data;
+  }
+};
+
+export { reconciliationService };
+export default reconciliationService;


### PR DESCRIPTION
## Summary
- add a new hook `useReconciliation` and service for API calls
- implement `ReconciliationDashboard` component
- add page and route for the dashboard

## Testing
- `npm ci`
- `npm test` *(fails: AIContext.test.jsx and ProtectedRoute.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_684bc4fcea388332888bd151598431cc