### PR TITLE
Add confidence indicator component

### DIFF
--- a/src/components/AIPipeline/MatchCard.jsx
+++ b/src/components/AIPipeline/MatchCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ConfidenceScore from './ConfidenceScore.jsx';
+import ConfidenceIndicator from '../reconciliation/ConfidenceIndicator.jsx';
 
 const MatchCard = ({ match, onClick }) => (
   <div
@@ -12,7 +12,10 @@ const MatchCard = ({ match, onClick }) => (
         <p className="text-sm text-gray-500">Alle: {match.alle}</p>
         <p className="text-sm text-gray-500">Aspire: {match.aspire}</p>
       </div>
-      <ConfidenceScore score={match.confidence} />
+      <ConfidenceIndicator
+        confidence={match.confidence}
+        recommendation={match.recommendation}
+      />
     </div>
   </div>
 );

--- a/src/components/reconciliation/ConfidenceIndicator.jsx
+++ b/src/components/reconciliation/ConfidenceIndicator.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { CheckCircle, AlertTriangle, XCircle } from 'lucide-react';
+
+const ConfidenceIndicator = ({ confidence = 0, recommendation, showValue = true }) => {
+  const color = confidence >= 0.95
+    ? 'text-green-600'
+    : confidence >= 0.8
+    ? 'text-yellow-600'
+    : 'text-red-600';
+
+  const Icon = confidence >= 0.95 ? CheckCircle : confidence >= 0.8 ? AlertTriangle : XCircle;
+
+  const recText = recommendation === 'AUTO_APPROVE'
+    ? 'Auto-Approve'
+    : recommendation === 'REVIEW_RECOMMENDED'
+    ? 'Manual Review'
+    : recommendation === 'LIKELY_MISMATCH'
+    ? 'Likely Mismatch'
+    : 'Unknown';
+
+  return (
+    <div className="flex items-center space-x-2" title={recText}>
+      <Icon className={`w-4 h-4 ${color}`} />
+      {showValue && (
+        <span className={`text-sm font-medium ${color}`}>{Math.round(confidence * 100)}%</span>
+      )}
+    </div>
+  );
+};
+
+export default ConfidenceIndicator;

--- a/src/pages/ReconciliationAI/MatchDetails.jsx
+++ b/src/pages/ReconciliationAI/MatchDetails.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import JsonViewer from '../../components/AIPipeline/JsonViewer.jsx';
-import ConfidenceScore from '../../components/AIPipeline/ConfidenceScore.jsx';
+import ConfidenceIndicator from '../../components/reconciliation/ConfidenceIndicator.jsx';
 import CorrectionForm from './CorrectionForm.jsx';
 import TierGuard from '../../components/auth/TierGuard.jsx';
 
@@ -22,7 +22,7 @@ const MatchDetails = () => {
     <TierGuard allowedTiers={['professional']}>
       <div className="max-w-3xl mx-auto p-6 space-y-4">
         <h1 className="text-2xl font-bold">Match #{id}</h1>
-        <ConfidenceScore score={data.confidence} />
+        <ConfidenceIndicator confidence={data.confidence} />
         <JsonViewer data={data.posRecord} label="POS Record" />
         <JsonViewer data={data.alleRecord} label="Alle Record" />
         <JsonViewer data={data.aspireRecord} label="Aspire Record" />


### PR DESCRIPTION
## Summary
- add new ConfidenceIndicator component
- integrate indicator into MatchCard and MatchDetails

## Testing
- `npm test` *(fails: vitest not found or tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_684bc86f4cc88332b279e551a3d4ee8a