### PR TITLE
Add MatchingProgress component

### DIFF
--- a/src/components/reconciliation/MatchingProgress.jsx
+++ b/src/components/reconciliation/MatchingProgress.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { CheckCircle, XCircle, Clock } from 'lucide-react';
+
+const MatchingProgress = ({ job, onCancel }) => {
+  if (!job) return null;
+
+  const { status = 'processing', progress = 0, message } = job;
+
+  const color = progress < 0 ? 'bg-red-500' : progress < 100 ? 'bg-blue-500' : 'bg-green-500';
+
+  const StatusIcon = status === 'failed'
+    ? XCircle
+    : status === 'completed'
+    ? CheckCircle
+    : Clock;
+
+  return (
+    <div className="border rounded p-4 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <StatusIcon className="w-5 h-5" />
+          <span className="font-semibold">Job ID: {job.jobId || job.id}</span>
+        </div>
+        {status === 'processing' && (
+          <button
+            onClick={onCancel}
+            className="text-sm text-red-600 border border-red-300 px-2 py-1 rounded"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+      <div className="text-sm text-gray-600">{message || 'Processing...'}</div>
+      <div className="w-full bg-gray-200 h-2 rounded">
+        <div
+          className={`h-2 rounded ${color}`}
+          style={{ width: `${Math.max(0, Math.min(100, progress))}%` }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MatchingProgress;


### PR DESCRIPTION
## Summary
- add `MatchingProgress` to display reconciliation job progress
- enhance dashboard to use the websocket for progress updates and results

## Testing
- `npm test` *(fails: vitest not found / syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_684bce3d3880833285e0a653d2c615e0